### PR TITLE
fix(test): fix locator for dropdown on create component page

### DIFF
--- a/integration-tests/support/pages/ComponentsPage.ts
+++ b/integration-tests/support/pages/ComponentsPage.ts
@@ -39,9 +39,12 @@ export class ComponentPage extends AbstractWizardPage {
   }
 
   setPipeline(pipeline: string) {
-    cy.get(ComponentsPagePO.dropdown, { timeout: 80000 }).eq(0).should('be.enabled').click();
-    cy.get(ComponentsPagePO.dropdown).get('a').contains(pipeline).click();
+    cy.contains('.pf-v5-c-form__group', 'Pipeline').within(($form) => {
+      cy.get(ComponentsPagePO.dropdown).click();
+      cy.contains('li', pipeline).click();
+    });
   }
+
   public componentName: string;
 
   editComponentName(newName: string) {


### PR DESCRIPTION
## Description
Fix the Basic path as there are now two dropdown fields on a component creation page. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
